### PR TITLE
Fix data path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Navigate into `./ChatApp.AppHost/`.
 
 ## Sample Product Data
 
-To load sample product data into Azure AI Search as vector store, use the notebook inside `./data/`.
+To load sample product data into Azure AI Search as vector store, use the notebook inside `./src/data/`.
 
 ## Guidance
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the path to the notebook for loading sample product data into Azure AI Search as a vector store.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L213-R213): Updated the path from `./data/` to `./src/data/` for loading sample product data into Azure AI Search.